### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
-=begin
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
-=end
 
   def new
     @item = Item.new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,8 +13,9 @@ class Item < ApplicationRecord
     validates :description
     validates :price
   end
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "Out of setting range" }
-  validates :price, numericality: { only_integer: true, message: "Half-width number." }
+  validates :price,
+            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'Out of setting range' }
+  validates :price, numericality: { only_integer: true, message: 'Half-width number.' }
   validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :condition_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :ship_area_id, numericality: { other_than: 1, message: "can't be blank" }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
                 <%= item.item_name %>
               </h3>
               <div class='item-price'>
-                <span><%= item.price %>円<br><%= item.ship_charge_id %></span>
+                <span><%= item.price %>円<br><%= item.ship_charge.name %></span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,9 +128,6 @@
     </div>
     <% if @items.present? %>
       <ul class='item-lists'>
-
-        <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      
         <% @items.each do |item| %>  
           <li class='list'>
             <%= link_to "#" do %>
@@ -159,12 +156,7 @@
             <% end %>
           </li>
         <% end %>
-        
-          <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-        <%# 商品がある場合は表示されないようにしましょう %>
-    <% else %>  
+    <% else %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -182,8 +174,6 @@
           </div>
           <% end %>
         </li>
-        <%# //商品がある場合は表示されないようにしましょう %>
-        <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       </ul>
     <% end %>  
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,59 +126,66 @@
     <div class="subtitle" >
       新規投稿商品
     </div>
-    <ul class='item-lists'>
+    <% if @items.present? %>
+      <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+        <% @items.each do |item| %>  
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.item_name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.ship_charge_id %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
+        <% end %>
+        
+          <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <%# 商品がある場合は表示されないようにしましょう %>
+    <% else %>  
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
+          <% end %>
+        </li>
+        <%# //商品がある場合は表示されないようにしましょう %>
+        <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      </ul>
+    <% end %>  
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erbZone.Identifier
+++ b/app/views/items/index.html.erbZone.Identifier
@@ -1,3 +1,3 @@
 [ZoneTransfer]
 ZoneId=3
-ReferrerUrl=C:\Users\wisse\Downloads\furima_ëfçﬁ_rails7.zip
+ReferrerUrl=C:\Users\wisse\Downloads\furima_ëfçﬁ_rails7 (1).zip

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :destroy] 
+  resources :items, only: [:new, :create, :index, :destroy] 
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Item, type: :model do
       it 'priceが全角数字だと出品できない' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range", "Price Half-width number.")
+        expect(@item.errors.full_messages).to include('Price Out of setting range', 'Price Half-width number.')
       end
 
       it 'priceが¥300より少ない時は出品できない' do
@@ -93,8 +93,8 @@ RSpec.describe Item, type: :model do
       it 'userが紐づいていないと登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
-      end  
+        expect(@item.errors.full_messages).to include('User must exist')
+      end
     end
   end
 end


### PR DESCRIPTION
# What
・出品した商品の一覧をトップページに表示する。
・ログインの有無に関わらず一覧表示できるようにする。

# Why
furima-39482のトップページに一覧表示機能を実装するため。

商品のデータがない場合は、ダミー商品が表示されている動画
https://i.gyazo.com/801855d35b253e934e277722321fb42e.mp4

 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://i.gyazo.com/600952183e8edd472fcb239559a03291.mp4

ご確認よろしくお願いします。
